### PR TITLE
retrieveNode crashes if Consul agent is down

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -137,6 +137,7 @@ func (c *Candidate) retrieveNode() {
 	agent, err := consul.Agent().Self()
 	if err != nil {
 		logrus.Warnln("Unable to retrieve node name.")
+		return
 	}
 	c.node = agent["Config"]["NodeName"].(string)
 }


### PR DESCRIPTION
Due to assigning a null value to a string. E.g. try calling "IsLeader()" with Consul up/down. 
